### PR TITLE
feat(redsocks): make iptables interface configurable

### DIFF
--- a/redsocks/Dockerfile
+++ b/redsocks/Dockerfile
@@ -1,12 +1,12 @@
 # Redsocks docker image.
-#
-# VERSION 0.0.1
 
 FROM debian:jessie
 
 MAINTAINER Nicolas Carlier <https://github.com/ncarlier>
 
 ENV DEBIAN_FRONTEND noninteractive
+
+ENV DOCKER_NET docker0
 
 # Install packages
 RUN apt-get update && apt-get install -y redsocks iptables

--- a/redsocks/README.md
+++ b/redsocks/README.md
@@ -19,7 +19,9 @@ docker run --privileged=true --net=host -d ncarlier/redsocks 1.2.3.4 3128
 
 Replace the IP and the port by those of your proxy.
 
-The container will start redsocks and automatically configure iptable to forward **all** the TCP traffic through the proxy.
+The container will start redsocks and automatically configure iptable to forward **all** the TCP traffic of the `$DOCKER_NET` interface (`docker0` by default) through the proxy.
+
+You can forward all the TCP traffic regardless the interface by unset the `DOCKER_NET` variable: `-e DOCKER_NET`.
 
 If you want to add exception for an IP or a range of IP you can edit the whitelist file.
 Once edited you can replace this file into the container by mounting it:

--- a/redsocks/redsocks-fw.sh
+++ b/redsocks/redsocks-fw.sh
@@ -16,8 +16,13 @@ fw_setup() {
   iptables -t nat -A REDSOCKS -p tcp --dport 80 -j REDIRECT --to-ports 12345
   iptables -t nat -A REDSOCKS -p tcp -j REDIRECT --to-ports 12346
 
-  # Finally we tell iptables to use the ‘REDSOCKS’ chain for all outgoing connection in the network interface ‘eth0′.
-  iptables -t nat -A PREROUTING -i docker0 -p tcp -j REDSOCKS
+  # Finally we tell iptables to use the ‘REDSOCKS’ chain for all outgoing connection in the network interface ‘$DOCKER_NET′.
+  if [ -z "$DOCKER_NET" ]
+  then
+    iptables -t nat -A PREROUTING -p tcp -j REDSOCKS
+  else
+    iptables -t nat -A PREROUTING -i $DOCKER_NET -p tcp -j REDSOCKS
+  fi
 }
 
 ##########################


### PR DESCRIPTION
Added `$DOCKER_NET` variable to give the possibility to specify the network interface to forward.
If the variable is disabled, then ALL interfaces are forwarded.
